### PR TITLE
New description property on powercfgplan & more

### DIFF
--- a/PowerCfg/PowerCfg.psd1
+++ b/PowerCfg/PowerCfg.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PowerCfg.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.2.0'
+ModuleVersion = '0.2.1'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Desktop','Core')

--- a/PowerCfg/Public/Get-PowercfgSettings.ps1
+++ b/PowerCfg/Public/Get-PowercfgSettings.ps1
@@ -121,46 +121,44 @@ function Get-PowercfgSettings {
             $cfg = $cfg[3..(($cfg.count)-1)]
 
             if($PSCmdlet.ParameterSetName -eq 'List'){
-                if($List){
-                    if($Name){
-                        $cfg = $cfg.Where({$_ -match $Name})
-                        if($null -eq $cfg){
-                            $PSCmdlet.ThrowTerminatingError(
-                                [System.Management.Automation.ErrorRecord]::new(
-                                        [System.ArgumentNullException]::new(
-                                            "-Name",
-                                            "$Name has no matches."
-                                        ),
-                                        "PowerScheme.Null",
-                                        [System.Management.Automation.ErrorCategory]::ObjectNotFound,
-                                        $Name
-                                )
+                if($Name){
+                    $cfg = $cfg.Where({$_ -match $Name})
+                    if($null -eq $cfg){
+                        $PSCmdlet.ThrowTerminatingError(
+                            [System.Management.Automation.ErrorRecord]::new(
+                                    [System.ArgumentNullException]::new(
+                                        "-Name",
+                                        "$Name has no matches."
+                                    ),
+                                    "PowerScheme.Null",
+                                    [System.Management.Automation.ErrorCategory]::ObjectNotFound,
+                                    $Name
                             )
-                        }
+                        )
                     }
-                    if($Active){
-                        $cfg = $cfg.where({$_ -match "(.+)\s{1}\*$"})
-                    }
-                    foreach($plan in $cfg){
-                        $null = $plan -match "\((.+)\)";$name = $Matches[1]
-                        $null = $plan -match "\s{1}(\S+\d+\S+)\s{1}";$guid = $Matches[1]
+                }
+                if($Active){
+                    $cfg = $cfg.where({$_ -match "(.+)\s{1}\*$"})
+                }
+                foreach($plan in $cfg){
+                    $null = $plan -match "\((.+)\)";$name = $Matches[1]
+                    $null = $plan -match "\s{1}(\S+\d+\S+)\s{1}";$guid = $Matches[1]
 
-                        if($plan -match "\*$"){$temp = $true}
-                        elseif($plan -notmatch "\*$"){$temp = $false}
+                    if($plan -match "\*$"){$temp = $true}
+                    elseif($plan -notmatch "\*$"){$temp = $false}
 
-                        $plan = [PSCustomObject]@{
-                            Name=$name
-                            Guid=[Guid]$guid
-                            Active=[bool]$temp
-                        }
-                        $plan = [PowerCfgPlan]$plan
-                        if($ComputerName){
-                            $plan | Add-Member -MemberType NoteProperty -Name ComputerName -Value $ComputerName
-                        }
-                        $plan
-                        # Seeems redundant, but we need to save $plan with the correct object time for appending to
-                        # settings hidden property for easy pipeline usage.
+                    $plan = [PSCustomObject]@{
+                        Name=$name
+                        Guid=[Guid]$guid
+                        Active=[bool]$temp
                     }
+                    $plan = [PowerCfgPlan]$plan
+                    if($ComputerName){
+                        $plan | Add-Member -MemberType NoteProperty -Name ComputerName -Value $ComputerName
+                    }
+                    $plan
+                    # Seeems redundant, but we need to save $plan with the correct object type for appending to
+                    # settings hidden property for easy pipeline usage.
                 }
             }
             if($PSCmdlet.ParameterSetName -eq "Query"){

--- a/PowerCfg/Scripts/PowerCfgPlan.ps1
+++ b/PowerCfg/Scripts/PowerCfgPlan.ps1
@@ -1,16 +1,19 @@
 class PowerCfgPlan {
     [string]    $Name
+    [string]    $Description
     [Guid]      $Guid
     [Bool]      $Active
     <# Define the class. Try constructors, properties, or methods. #>
-    PowerCfgPlan([String]$Name, [Guid]$Guid, [Bool]$Active){
+    PowerCfgPlan([String]$Name, [String]$Description, [Guid]$Guid, [Bool]$Active){
         $this.Name = $Name
+        $this.Description = $Description
         $this.Guid = $Guid
         $this.Active = $Active
     }
     
     PowerCfgPlan([PSObject]$Plan){
         $this.Name = [String]$Plan.Name
+        $this.Description = $Plan.Description
         $this.Guid = [Guid]$Plan.Guid
         $this.Active = [Bool]$Plan.Active
     }


### PR DESCRIPTION
New Description property for seeing the descriptions of power plans, usually hidden in WMI.
Fix applied to Set-PowercfgScheme's -Description parameter when using pipe vs not using pipe. Results should be consistent.